### PR TITLE
fix: improve windows compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"memAgent/cipher.yml"
 	],
 	"scripts": {
-		"clean": "rm -rf dist",
+                "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
 		"prebuild": "pnpm run clean",
 		"build": "pnpm run build-ui && tsup && pnpm run copy-ui-dist",
 		"build:no-ui": "tsup && pnpm run copy-ui-dist",
@@ -83,9 +83,9 @@
 		"eslint": "^9.29.0",
 		"eslint-config-prettier": "^10.1.5",
 		"pg": "^8.16.3",
-		"prettier": "^3.5.3",
-		"recheck": "^4.5.0",
-		"supertest": "^7.1.4",
+                "prettier": "^3.5.3",
+                "recheck": "^4.5.0",
+                "supertest": "^7.1.4",
 		"ts-node": "^10.9.2",
 		"tsup": "^8.5.0",
 		"tsx": "^4.19.2",

--- a/scripts/copy-ui-dist.ts
+++ b/scripts/copy-ui-dist.ts
@@ -88,9 +88,13 @@ async function copyUIBuild(): Promise<void> {
 			throw new Error('Standalone server.js not found after copying');
 		}
 
-		// Ensure standalone server is executable
-		await fs.chmod(standaloneServerPath, '755');
-		console.log('✅ Standalone server configured');
+                // Ensure standalone server is executable (skip on Windows)
+                if (process.platform !== 'win32') {
+                        await fs.chmod(standaloneServerPath, 0o755);
+                        console.log('✅ Standalone server configured');
+                } else {
+                        console.log('⚠️  Skipping chmod on Windows');
+                }
 
 		// Create a simple package.json for the distribution if it doesn't exist
 		const distPackageJsonPath = path.join(targetDir, 'package.json');


### PR DESCRIPTION
## Summary
- replace Unix-specific clean command with Node `fs.rmSync` for cross-platform builds
- skip `chmod` in copy UI script on Windows systems

## Testing
- `npm test` *(fails: process terminated after lengthy execution; partial results shown)*

------
https://chatgpt.com/codex/tasks/task_e_68ad735fd4b08333b775c8d49f8cf61f