### PR TITLE
Use path.sep for dist detection

### DIFF
--- a/src/app/web/__test__/web-server.test.ts
+++ b/src/app/web/__test__/web-server.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { isCompiledPath } from '../web-server.js';
+
+describe('isCompiledPath', () => {
+        it('detects compiled path on Unix', () => {
+                const filePath = '/usr/src/app/dist/src/app/web/web-server.js';
+                expect(isCompiledPath(filePath, path.posix)).toBe(true);
+        });
+
+        it('detects compiled path on Windows', () => {
+                const filePath = 'C:\\project\\dist\\src\\app\\web\\web-server.js';
+                expect(isCompiledPath(filePath, path.win32)).toBe(true);
+        });
+
+        it('detects source path on Unix', () => {
+                const filePath = '/usr/src/app/src/app/web/web-server.ts';
+                expect(isCompiledPath(filePath, path.posix)).toBe(false);
+        });
+
+        it('detects source path on Windows', () => {
+                const filePath = 'C:\\project\\src\\app\\web\\web-server.ts';
+                expect(isCompiledPath(filePath, path.win32)).toBe(false);
+        });
+});

--- a/src/app/web/web-server.ts
+++ b/src/app/web/web-server.ts
@@ -11,6 +11,14 @@ export interface WebServerConfig {
 	wsUrl?: string;
 }
 
+export function isCompiledPath(
+        filePath: string,
+        pathModule: typeof path = path
+): boolean {
+        const normalized = pathModule.normalize(filePath);
+        return normalized.includes(`${pathModule.sep}dist${pathModule.sep}`);
+}
+
 export class WebServerManager {
 	private config: WebServerConfig;
 	private process: ChildProcess | null = null;
@@ -22,8 +30,8 @@ export class WebServerManager {
 		const currentFileUrl = import.meta.url;
 		const currentFilePath = fileURLToPath(currentFileUrl);
 
-		// Check if we're running from dist (compiled) or src (development)
-		const isCompiledVersion = currentFilePath.includes('/dist/');
+                // Check if we're running from dist (compiled) or src (development)
+                const isCompiledVersion = isCompiledPath(currentFilePath);
 
 		if (isCompiledVersion) {
 			// When running from dist/src/app/index.cjs, UI is at dist/src/app/ui


### PR DESCRIPTION
## Summary
- use path.sep-based logic to detect compiled dist directory
- add tests for Unix and Windows path handling in web server

## Testing
- `pnpm test src/app/web/__test__/web-server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0c0f2695c83338b07684f54c37694